### PR TITLE
Changed generation of temporary all-specs yaml to using a string - Is…

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,4 @@
 alias(
-    name = "spec",
-    actual = "//src/main/java/com/gs/crdtools:spec",
-)
-
-alias(
     name = "openapi-src-genner",
     actual = "//src/main/java/com/gs/crdtools:openapi-src-genner",
 )

--- a/src/main/java/com/gs/crdtools/BUILD
+++ b/src/main/java/com/gs/crdtools/BUILD
@@ -74,21 +74,12 @@ java_binary(
 )
 
 genrule(
-    name = "spec",
-    outs = ["all-specs-only.yaml"],
-    visibility = ["//visibility:public"],
-    cmd = "$(location gen-source-from-spec) \"$@\"",
-    tools = ["gen-source-from-spec"],
-)
-
-genrule(
     name = "kcc-java-genned",
     outs = [
-        "all-specs.yaml",
         "genned.srcjar",
     ],
     visibility = ["//visibility:public"],
-    cmd = "$(location gen-source-from-spec) $(location all-specs.yaml) $(location genned.srcjar)",
+    cmd = "$(location gen-source-from-spec) $(location genned.srcjar)",
     tools = [
         "gen-source-from-spec",
     ],

--- a/src/main/java/com/gs/crdtools/MyCodegen.java
+++ b/src/main/java/com/gs/crdtools/MyCodegen.java
@@ -66,4 +66,3 @@ public class MyCodegen extends SpringCodegen {
         return toGetter(name);
     }
 }
-

--- a/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
+++ b/src/main/java/com/gs/crdtools/SourceGenFromSpec.java
@@ -17,55 +17,39 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 /**
- * This class is used to generate the source code from the OpenAPI specs.
- * It can be run using the following bazel rules:
- * - bazel build //:spec (for the all-specs-only.yaml file)
- * - bazel build //:kcc_java_genned for the source code generation.
+ * This class is used to generate POJO(s) from the given OpenAPIV3 specifications.
+ * It can be run using the following bazel rule:
+ * - bazel build //:kcc_java_genned.
  */
 public class SourceGenFromSpec {
 
     /**
-     * Generate the all-specs.yaml file or the complete source code, according
-     * to the number of parameters given:
-     * 1 - generate the all-specs-only.yaml file
-     * 2 - generate the complete source code from the spec file.
-     * @param args The all-specs.yaml and genned.srcjar locations.
+     * Generate POJOs from the given OpenAPIV3 specifications and write them to the given path.
+     * @param args The genned.srcjar location, that is, the path where the generated POJOs will be written.
      * @throws IOException If any error occurs while loading the given paths.
-     * @throws IllegalArgumentException If the number of arguments is not 1 or 2.
+     * @throws IllegalArgumentException If the number of arguments is not 1.
      */
     public static void main(String[] args) throws IllegalArgumentException, IOException {
         if (args.length == 1) {
-            // Generate  yaml only -- rule //:spec
-            var specFile = Paths.get(args[0]);
-
-            extractSpecs(specFile);
-        } else if (args.length == 2) {
-            // Generate yaml and java -- rule //:kcc_java_genned
-            var specFile = Paths.get(args[0]);
-            var out = Paths.get(args[1]);
-
-            extractSpecs(specFile);
-
+            var outputPath = Paths.get(args[0]);
+            var openApiSpecs = extractSpecs();
             var outputDir = Files.createTempDirectory("openAPIGen");
-            generateSourceInDir(specFile, out, outputDir);
+            generateSourceInDir(openApiSpecs, outputPath, outputDir);
         } else {
-            throw new IllegalArgumentException("Invalid number of arguments. " +
-                    "Expected 1 or 2, got " + args.length);
+            throw new IllegalArgumentException("Invalid number of arguments. Expected 1, got " + args.length);
         }
     }
 
     /**
-     * Generate source code from the given spec file to a temporary directory (outputDir),
-     * then write the contents of the temporary directory to the given out Path.
-     * @param specFile The spec file to generate source code from.
+     * Generate POJOs from a given OpenAPIV3 specification string in a given directory.
+     * @param specs The OpenAPIV3 specification yaml file in the form of a string.
      * @param out The output path.
      * @param outputDir The temporary directory to write the generated source code to.
      * @throws IOException If any error occurs while loading the given paths.
-     * @throws RuntimeException If any error arises during the writing process.
      */
-    private static void generateSourceInDir(Path specFile, Path out, Path outputDir) throws IOException, RuntimeException {
+    private static void generateSourceInDir(String specs, Path out, Path outputDir) throws IOException {
         var cc = new CodegenConfigurator()
-                .setInputSpecURL(specFile.toAbsolutePath().toString())
+                .setInputSpec(specs)
                 .setLang(MyCodegen.class.getCanonicalName())
                 .setOutputDir(outputDir.toAbsolutePath().toString())
                 .setModelPackage("kccapi")
@@ -86,18 +70,17 @@ public class SourceGenFromSpec {
 
     /**
      * Copy the keys and values from inner into a mutable Map and return it.
+     * @param inner The map to copy.
      */
     private static <K, V> Map<K, V> mutable(Map<K, V> inner) {
         return new java.util.HashMap<>(inner);
     }
 
     /**
-     * Extract all CRD definitions and pull out the openapi specs according to these.
-     * Finally, write the specs to the specFile (yaml file).
-     * @param specFile The path to the final spec file location.
-     * @throws IOException If the k8s-config-connector has not been downloaded.
+     * Extract the OpenAPIV3 specs from a yaml file containing all CRD(s) objects.
+     * Return the specs as a string.
      */
-    private static void extractSpecs(Path specFile) throws IOException {
+    private static String extractSpecs() {
         List<Object> allTheYamls = SpecExtractorHelper.getCrdsYaml();
 
         var metadataSpec = HashMap.of("type", V1ObjectMeta.class.getSimpleName());
@@ -114,21 +97,19 @@ public class SourceGenFromSpec {
                 "components", HashMap.of("schemas", onlySpecs)
         );
 
-        writeSpecsToFile(specFile, full);
+        return writeSpecsToString(full);
     }
 
     /**
-     * Write the openapi specs to the given file (specFile).
-     * @param specFile The resulting yaml file containing the openapi specs.
+     * Write the OpenApiV3 specs to a string and return it.
      * @param openapiSpecs A map containing the openapi specs.
-     * @throws IOException If any error occurs while writing the file.
      */
-    private static void writeSpecsToFile(Path specFile, HashMap<String, Serializable> openapiSpecs) throws IOException {
+    private static String writeSpecsToString(HashMap<String, Serializable> openapiSpecs) {
         var dumperOptions = new DumperOptions();
         dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         var yaml = new Yaml(dumperOptions);
 
-        Files.writeString(specFile, yaml.dump(VavrHelpers.deepToJava(openapiSpecs, List.empty(), HashSet.of(String.class))));
+        return yaml.dump(VavrHelpers.deepToJava(openapiSpecs, List.empty(), HashSet.of(String.class)));
     }
 
 }

--- a/src/main/java/com/gs/crdtools/SourceGeneratorHelper.java
+++ b/src/main/java/com/gs/crdtools/SourceGeneratorHelper.java
@@ -14,8 +14,7 @@ import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 
 /**
- * A helper class to help with the generation of source code given an all-specs.yaml file
- * and an output file.
+ * A helper class to help with the generation of source code given some OpenAPIV3 specifications.
  */
 public class SourceGeneratorHelper {
 
@@ -27,11 +26,11 @@ public class SourceGeneratorHelper {
      * @throws RuntimeException If any issues occur while copying the content.
      */
     static void writeJarToOutput(Path out, Path outputDir) throws IOException, RuntimeException {
-        var jarOut = new JarOutputStream(Files.newOutputStream(out));
-        var root = outputDir.resolve("src/main/java/kccapi");
+        var root = outputDir.resolve("src/main/java/kccapi"); // NB: sorted for stable output
 
         // try with resources is used to close the jarOut stream when the block is exited
-        try (var stream = Files.walk(root).sorted()) { // NB: sorted for stable output
+        try (var jarOut = new JarOutputStream(Files.newOutputStream(out));
+             var stream = Files.walk(root).sorted()) {
             stream.forEach(p -> {
                 if (Files.isRegularFile(p) && p.toString().endsWith(".java")) {
                     var path = root.relativize(p).toString();
@@ -46,8 +45,6 @@ public class SourceGeneratorHelper {
                     }
                 }
             });
-        } finally {
-            jarOut.close();
         }
     }
 

--- a/src/main/java/com/gs/crdtools/SpecExtractorHelper.java
+++ b/src/main/java/com/gs/crdtools/SpecExtractorHelper.java
@@ -8,7 +8,7 @@ import io.vavr.collection.Map;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * A helper class to extract the openAPI specs from a given yaml file.
+ * A helper class to extract the openAPI specs from a given yaml file in the format of a string.
  */
 public class SpecExtractorHelper {
 

--- a/src/test/java/com/gs/crdtools/BUILD
+++ b/src/test/java/com/gs/crdtools/BUILD
@@ -9,8 +9,7 @@ java_junit5_test(
         "//src/main/java/com/gs/crdtools:spec-extractor",
         "//src/main/java/com/gs/crdtools:openapi-src-genner",
         "//src/main/java/com/gs/crdtools:gen-source-from-spec",
-        "@maven//:io_vavr_vavr",
-        "@bazel_tools//tools/java/runfiles"
+        "@bazel_tools//tools/java/runfiles",
     ],
     test_package = "com.gs.crdtools",
     size = "small",
@@ -18,3 +17,4 @@ java_junit5_test(
         "//src/test/resources:all",
     ],
 )
+

--- a/src/test/java/com/gs/crdtools/SourceGeneratorTest.java
+++ b/src/test/java/com/gs/crdtools/SourceGeneratorTest.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import com.google.devtools.build.runfiles.Runfiles;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
…sue #19 (#20)

* migration from codegen CLI to codegen

* all-specs is now a string instead of a temporary yaml file